### PR TITLE
Implement AsyncSender for non-blocking log delivery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,9 @@ CloudLog is a Go structured logging library for Grafana Loki integration. Module
 
 ```bash
 go test ./...                              # Run all tests
-go test ./logger/                          # Run tests for a specific package
+go test -race ./...                        # Run with race detector
 go test -run TestFunctionName ./package/   # Run a single test
+golangci-lint run ./...                    # Run linter
 ./coverage.sh                              # Race detection + coverage
 ```
 
@@ -21,7 +22,7 @@ The root package (`cloudlog.go`) is a **facade** re-exporting from internal pack
 
 ### Core packages
 
-- **`logger/`** — `Logger` and `Sender` interfaces, `SyncSender`, and logger implementation. Log methods accept `context.Context`.
+- **`logger/`** — `Logger` and `Sender` interfaces, `SyncSender`, `AsyncSender`, and logger implementation. Log methods accept `context.Context`.
 - **`formatter/`** — `Formatter` interface returns `[]byte`. `LokiFormatter` (JSON) and `StringFormatter` (human-readable).
 - **`client/`** — `LogSender` interface and `LokiClient`. Sends `LokiEntry` to Loki's HTTP push API.
 - **`errors/`** — Sentinel errors with `Is*` helpers.
@@ -32,19 +33,14 @@ The root package (`cloudlog.go`) is a **facade** re-exporting from internal pack
 Logger.Info(ctx, msg, kv...)
   → formatter.Format(LogEntry) → []byte
   → Sender.Send(ctx, content, labels, timestamp)
-  → [SyncSender] builds LokiEntry → LogSender.Send(ctx, LokiEntry) → HTTP POST
+  → SyncSender: builds LokiEntry → HTTP POST (blocking)
+  → AsyncSender: pushes to buffer → worker batches → HTTP POST (background)
 ```
-
-### Key interfaces
-
-- **`Logger`** — Info/Error/Debug/Warn + With/WithJob
-- **`Sender`** — Send(ctx, content, labels, timestamp). SyncSender sends immediately. AsyncSender (future) will buffer.
-- **`Formatter`** — Format(LogEntry) → []byte
-- **`LogSender`** — Send(ctx, LokiEntry). Low-level HTTP transport.
 
 ### Public API
 
-- **Constructors:** `New`, `NewSyncSender`, `NewClient`, `NewLokiFormatter`
+- **Constructors:** `New`, `NewSyncSender`, `NewAsyncSender`, `NewClient`, `NewLokiFormatter`
 - **Logger options:** `WithJob`, `WithMetadata`, `WithFormatter`, `WithLabelKeys`, `WithMinLevel`
+- **AsyncSender options:** `WithBufferSize`, `WithBatchSize`, `WithFlushInterval`, `WithBlockOnFull`, `WithErrorHandler`
 - **Level constants:** `LevelDebug`, `LevelInfo`, `LevelWarn`, `LevelError`
 - **Error helpers:** `IsFormatError`, `IsConnectionError`, `IsResponseError`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,6 @@ Logger.Info(ctx, msg, kv...)
 
 - **Constructors:** `New`, `NewSyncSender`, `NewAsyncSender`, `NewClient`, `NewLokiFormatter`
 - **Logger options:** `WithJob`, `WithMetadata`, `WithFormatter`, `WithLabelKeys`, `WithMinLevel`
-- **AsyncSender options:** `WithBufferSize`, `WithBatchSize`, `WithFlushInterval`, `WithBlockOnFull`, `WithErrorHandler`
+- **AsyncSender options:** `WithBufferSize`, `WithBatchSize`, `WithFlushInterval`, `WithBlockOnFull`, `WithErrorHandler`, `WithSendTimeout`
 - **Level constants:** `LevelDebug`, `LevelInfo`, `LevelWarn`, `LevelError`
 - **Error helpers:** `IsFormatError`, `IsConnectionError`, `IsResponseError`

--- a/cloudlog.go
+++ b/cloudlog.go
@@ -25,10 +25,11 @@ const (
 
 // Type re-exports
 type (
-	Logger     = logger.Logger
-	Sender     = logger.Sender
-	HTTPClient = client.HTTPClient
-	Option     = logger.Option
+	Logger            = logger.Logger
+	Sender            = logger.Sender
+	HTTPClient        = client.HTTPClient
+	Option            = logger.Option
+	AsyncSenderOption = logger.AsyncSenderOption
 )
 
 // New creates a new Logger with the given sender and options
@@ -40,6 +41,20 @@ func New(sender logger.Sender, options ...logger.Option) logger.Logger {
 func NewSyncSender(c client.LogSender) *logger.SyncSender {
 	return logger.NewSyncSender(c)
 }
+
+// NewAsyncSender creates a buffered sender that delivers log entries asynchronously
+func NewAsyncSender(c client.LogSender, options ...logger.AsyncSenderOption) *logger.AsyncSender {
+	return logger.NewAsyncSender(c, options...)
+}
+
+// Async sender options
+var (
+	WithBufferSize    = logger.WithBufferSize
+	WithBatchSize     = logger.WithBatchSize
+	WithFlushInterval = logger.WithFlushInterval
+	WithBlockOnFull   = logger.WithBlockOnFull
+	WithErrorHandler  = logger.WithErrorHandler
+)
 
 // NewClient creates a new Loki client with the given credentials
 func NewClient(url, username, token string, httpClient client.HTTPClient) client.LogSender {

--- a/cloudlog.go
+++ b/cloudlog.go
@@ -54,6 +54,7 @@ var (
 	WithFlushInterval = logger.WithFlushInterval
 	WithBlockOnFull   = logger.WithBlockOnFull
 	WithErrorHandler  = logger.WithErrorHandler
+	WithSendTimeout   = logger.WithSendTimeout
 )
 
 // NewClient creates a new Loki client with the given credentials

--- a/cloudlog.go
+++ b/cloudlog.go
@@ -43,7 +43,7 @@ func NewSyncSender(c client.LogSender) *logger.SyncSender {
 }
 
 // NewAsyncSender creates a buffered sender that delivers log entries asynchronously
-func NewAsyncSender(c client.LogSender, options ...logger.AsyncSenderOption) *logger.AsyncSender {
+func NewAsyncSender(c client.LogSender, options ...AsyncSenderOption) *logger.AsyncSender {
 	return logger.NewAsyncSender(c, options...)
 }
 

--- a/docs/tdd.md
+++ b/docs/tdd.md
@@ -172,7 +172,8 @@ Send(ctx, content, labels, timestamp)
   → push entry to buffer channel (non-blocking)
   → background worker:
       → accumulate entries until batchSize or flushInterval
-      → group by job label → build LokiEntry per job
+      → group entries by full label set (including any keys added via WithLabelKeys)
+      → build a single batched LokiEntry with one stream per distinct label set
       → LogSender.Send(context.Background(), batchedEntry)
       → on error: call errorHandler
 ```

--- a/docs/tdd.md
+++ b/docs/tdd.md
@@ -137,6 +137,7 @@ logger/
   interfaces.go          — Logger, Sender interfaces
   logger.go              — logger implementation, options
   sender.go              — SyncSender
+  async_sender.go        — AsyncSender
 ```
 
 ## Configuration
@@ -160,20 +161,41 @@ LevelWarn  = 2
 LevelError = 3  // errors only
 ```
 
-## Future: AsyncSender
+## AsyncSender
 
-The `Sender` interface is designed to support async delivery:
+`AsyncSender` implements `Sender` with non-blocking, buffered delivery. A background worker batches entries and sends them to the underlying `LogSender`.
 
-```go
-type AsyncSender struct {
-    client LogSender
-    buffer chan senderEntry
-    // ... worker pool, batch config
-}
+### Data Flow
+
+```
+Send(ctx, content, labels, timestamp)
+  → push entry to buffer channel (non-blocking)
+  → background worker:
+      → accumulate entries until batchSize or flushInterval
+      → group by job label → build LokiEntry per job
+      → LogSender.Send(context.Background(), batchedEntry)
+      → on error: call errorHandler
 ```
 
-- `Send()` pushes to buffer (non-blocking)
-- Background workers batch entries and call `LogSender.Send()`
-- `Flush()` and `Close()` live on `AsyncSender`, not on `Logger`
-- Error handler callback for background send failures
-- Buffer-full behavior configurable (block or return error)
+### Flush and Close
+
+`Flush()` pushes a flush marker (entry with a response channel) into the buffer. When the worker encounters it, it sends the current partial batch, then closes the response channel. `Flush()` blocks until the response channel is closed.
+
+`Close()` calls `Flush()` to drain remaining entries, then signals the worker to stop.
+
+Both methods live on `AsyncSender`, not on `Logger`.
+
+### Error Handling
+
+- `Send()` returns `ErrBufferFull` if the buffer channel is full (non-blocking mode)
+- Background HTTP errors are passed to `errorHandler` callback (default: log to stderr)
+
+### AsyncSender Options
+
+| Option              | Default | Description                       |
+| ------------------- | ------- | --------------------------------- |
+| `WithBufferSize`    | 1000    | Buffer channel capacity           |
+| `WithBatchSize`     | 100     | Max entries per HTTP request      |
+| `WithFlushInterval` | 5s      | Max time between sends            |
+| `WithBlockOnFull`   | false   | Block vs return ErrBufferFull     |
+| `WithErrorHandler`  | stderr  | Callback for background errors    |

--- a/docs/tdd.md
+++ b/docs/tdd.md
@@ -169,7 +169,7 @@ LevelError = 3  // errors only
 
 ```
 Send(ctx, content, labels, timestamp)
-  → push entry to buffer channel (non-blocking)
+  → push entry to buffer channel (non-blocking by default, blocks if WithBlockOnFull)
   → background worker:
       → accumulate entries until batchSize or flushInterval
       → group entries by full label set (including any keys added via WithLabelKeys)

--- a/docs/tdd.md
+++ b/docs/tdd.md
@@ -174,7 +174,7 @@ Send(ctx, content, labels, timestamp)
       → accumulate entries until batchSize or flushInterval
       → group entries by full label set (including any keys added via WithLabelKeys)
       → build a single batched LokiEntry with one stream per distinct label set
-      → LogSender.Send(context.Background(), batchedEntry)
+      → LogSender.Send(ctx with sendTimeout, batchedEntry)
       → on error: call errorHandler
 ```
 
@@ -182,7 +182,7 @@ Send(ctx, content, labels, timestamp)
 
 `Flush()` pushes a flush marker (entry with a response channel) into the buffer. When the worker encounters it, it sends the current partial batch, then closes the response channel. `Flush()` blocks until the response channel is closed.
 
-`Close()` calls `Flush()` to drain remaining entries, then signals the worker to stop.
+`Close()` calls `Flush()` to drain remaining entries, then signals the worker to stop. Both `Flush()` and `Close()` return immediately if the sender is already closed.
 
 Both methods live on `AsyncSender`, not on `Logger`.
 
@@ -200,3 +200,4 @@ Both methods live on `AsyncSender`, not on `Logger`.
 | `WithFlushInterval` | 5s      | Max time between sends            |
 | `WithBlockOnFull`   | false   | Block vs return ErrBufferFull     |
 | `WithErrorHandler`  | stderr  | Callback for background errors    |
+| `WithSendTimeout`   | 30s     | Timeout per HTTP batch send       |

--- a/docs/tdd.md
+++ b/docs/tdd.md
@@ -189,6 +189,7 @@ Both methods live on `AsyncSender`, not on `Logger`.
 ### Error Handling
 
 - `Send()` returns `ErrBufferFull` if the buffer channel is full (non-blocking mode)
+- `Send()` returns `ErrSenderClosed` if called after `Close()` has been invoked
 - Background HTTP errors are passed to `errorHandler` callback (default: log to stderr)
 
 ### AsyncSender Options

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,6 +18,9 @@ var (
 
 	// ErrInvalidInput indicates invalid input parameters
 	ErrInvalidInput = errors.New("invalid input parameters")
+
+	// ErrBufferFull indicates the async sender buffer is full
+	ErrBufferFull = errors.New("log buffer is full")
 )
 
 // Error type check functions

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -21,6 +21,9 @@ var (
 
 	// ErrBufferFull indicates the async sender buffer is full
 	ErrBufferFull = errors.New("log buffer is full")
+
+	// ErrSenderClosed indicates the sender has been closed
+	ErrSenderClosed = errors.New("sender is closed")
 )
 
 // Error type check functions

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -1,0 +1,242 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/mwazovzky/cloudlog/client"
+	"github.com/mwazovzky/cloudlog/errors"
+)
+
+// entry represents a log entry waiting to be sent, or a flush marker.
+type entry struct {
+	content   []byte
+	labels    map[string]string
+	timestamp time.Time
+	flushCh   chan struct{} // non-nil for flush markers
+}
+
+// AsyncSender implements Sender with non-blocking, buffered delivery.
+// A background worker batches entries and sends them to the underlying LogSender.
+type AsyncSender struct {
+	client        client.LogSender
+	buffer        chan entry
+	batchSize     int
+	flushInterval time.Duration
+	blockOnFull   bool
+	done          chan struct{}
+	wg            sync.WaitGroup
+	errorHandler  func(error)
+	closed        bool
+	mu            sync.Mutex
+}
+
+// AsyncSenderOption configures an AsyncSender.
+type AsyncSenderOption func(*AsyncSender)
+
+// NewAsyncSender creates a buffered sender that delivers log entries asynchronously.
+func NewAsyncSender(client client.LogSender, options ...AsyncSenderOption) *AsyncSender {
+	s := &AsyncSender{
+		client:        client,
+		buffer:        make(chan entry, 1000),
+		batchSize:     100,
+		flushInterval: 5 * time.Second,
+		blockOnFull:   false,
+		done:          make(chan struct{}),
+		errorHandler:  func(err error) { log.Printf("cloudlog: send error: %v", err) },
+	}
+
+	for _, opt := range options {
+		opt(s)
+	}
+
+	s.wg.Add(1)
+	go s.worker()
+
+	return s
+}
+
+// Send buffers an entry for async delivery. Non-blocking by default.
+func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]string, timestamp time.Time) error {
+	e := entry{
+		content:   content,
+		labels:    labels,
+		timestamp: timestamp,
+	}
+
+	if s.blockOnFull {
+		select {
+		case s.buffer <- e:
+			return nil
+		case <-s.done:
+			return fmt.Errorf("%w: sender is closed", errors.ErrBufferFull)
+		}
+	}
+
+	select {
+	case s.buffer <- e:
+		return nil
+	default:
+		return fmt.Errorf("%w", errors.ErrBufferFull)
+	}
+}
+
+// Flush blocks until all buffered entries have been sent.
+func (s *AsyncSender) Flush() {
+	flushCh := make(chan struct{})
+	s.buffer <- entry{flushCh: flushCh}
+	<-flushCh
+}
+
+// Close flushes remaining entries and stops the background worker.
+func (s *AsyncSender) Close() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.closed = true
+	s.mu.Unlock()
+
+	s.Flush()
+	close(s.done)
+	s.wg.Wait()
+}
+
+// worker is the background goroutine that pulls entries, batches them, and sends.
+func (s *AsyncSender) worker() {
+	defer s.wg.Done()
+
+	batch := make([]entry, 0, s.batchSize)
+	ticker := time.NewTicker(s.flushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case e := <-s.buffer:
+			if e.flushCh != nil {
+				s.sendBatch(batch)
+				batch = batch[:0]
+				close(e.flushCh)
+				continue
+			}
+
+			batch = append(batch, e)
+			if len(batch) >= s.batchSize {
+				s.sendBatch(batch)
+				batch = batch[:0]
+			}
+
+		case <-ticker.C:
+			if len(batch) > 0 {
+				s.sendBatch(batch)
+				batch = batch[:0]
+			}
+
+		case <-s.done:
+			// Drain remaining entries from buffer
+			for {
+				select {
+				case e := <-s.buffer:
+					if e.flushCh != nil {
+						close(e.flushCh)
+						continue
+					}
+					batch = append(batch, e)
+				default:
+					if len(batch) > 0 {
+						s.sendBatch(batch)
+					}
+					return
+				}
+			}
+		}
+	}
+}
+
+// sendBatch groups entries by job label and sends one LokiEntry per job.
+func (s *AsyncSender) sendBatch(batch []entry) {
+	if len(batch) == 0 {
+		return
+	}
+
+	// Group entries by job label
+	byJob := make(map[string][]entry)
+	for _, e := range batch {
+		job := e.labels["job"]
+		byJob[job] = append(byJob[job], e)
+	}
+
+	for job, entries := range byJob {
+		values := make([][]string, 0, len(entries))
+		for _, e := range entries {
+			values = append(values, []string{
+				fmt.Sprintf("%d", e.timestamp.UnixNano()),
+				string(e.content),
+			})
+		}
+
+		// Use labels from first entry, ensure job is set
+		labels := make(map[string]string)
+		for k, v := range entries[0].labels {
+			labels[k] = v
+		}
+		labels["job"] = job
+
+		lokiEntry := client.LokiEntry{
+			Streams: []client.LokiStream{
+				{
+					Stream: labels,
+					Values: values,
+				},
+			},
+		}
+
+		if err := s.client.Send(context.Background(), lokiEntry); err != nil {
+			s.errorHandler(err)
+		}
+	}
+}
+
+// Option constructors for AsyncSender
+
+func WithBufferSize(size int) AsyncSenderOption {
+	return func(s *AsyncSender) {
+		if size > 0 {
+			s.buffer = make(chan entry, size)
+		}
+	}
+}
+
+func WithBatchSize(size int) AsyncSenderOption {
+	return func(s *AsyncSender) {
+		if size > 0 {
+			s.batchSize = size
+		}
+	}
+}
+
+func WithFlushInterval(d time.Duration) AsyncSenderOption {
+	return func(s *AsyncSender) {
+		if d > 0 {
+			s.flushInterval = d
+		}
+	}
+}
+
+func WithBlockOnFull(block bool) AsyncSenderOption {
+	return func(s *AsyncSender) {
+		s.blockOnFull = block
+	}
+}
+
+func WithErrorHandler(handler func(error)) AsyncSenderOption {
+	return func(s *AsyncSender) {
+		if handler != nil {
+			s.errorHandler = handler
+		}
+	}
+}

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -72,7 +72,7 @@ func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
-		return fmt.Errorf("%w", errors.ErrSenderClosed)
+		return errors.ErrSenderClosed
 	}
 	s.mu.Unlock()
 
@@ -87,7 +87,7 @@ func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]
 		case s.buffer <- e:
 			return nil
 		case <-s.done:
-			return fmt.Errorf("%w", errors.ErrSenderClosed)
+			return errors.ErrSenderClosed
 		}
 	}
 
@@ -95,7 +95,7 @@ func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]
 	case s.buffer <- e:
 		return nil
 	default:
-		return fmt.Errorf("%w", errors.ErrBufferFull)
+		return errors.ErrBufferFull
 	}
 }
 

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -35,6 +35,7 @@ type AsyncSender struct {
 	errorHandler  func(error)
 	closed        bool
 	mu            sync.Mutex
+	closeOnce     sync.Once
 }
 
 // AsyncSenderOption configures an AsyncSender.
@@ -110,22 +111,18 @@ func (s *AsyncSender) Flush() {
 }
 
 // Close flushes remaining entries and stops the background worker.
+// Safe for concurrent calls.
 func (s *AsyncSender) Close() {
-	s.mu.Lock()
-	if s.closed {
-		s.mu.Unlock()
-		return
-	}
-	// Flush before marking closed so Flush() actually drains via marker
-	s.mu.Unlock()
-	s.Flush()
-	s.mu.Lock()
-	s.closed = true
-	s.mu.Unlock()
+	s.closeOnce.Do(func() {
+		s.Flush()
 
-	s.Flush()
-	close(s.done)
-	s.wg.Wait()
+		s.mu.Lock()
+		s.closed = true
+		s.mu.Unlock()
+
+		close(s.done)
+		s.wg.Wait()
+	})
 }
 
 // worker is the background goroutine that pulls entries, batches them, and sends.

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -65,6 +65,9 @@ func NewAsyncSender(client client.LogSender, options ...AsyncSenderOption) *Asyn
 }
 
 // Send buffers an entry for async delivery. Non-blocking by default.
+// The caller's context is intentionally not propagated to the HTTP send —
+// entries are sent later by a background worker, and the original context
+// may already be cancelled. Use WithSendTimeout to bound HTTP send duration.
 func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]string, timestamp time.Time) error {
 	s.mu.Lock()
 	if s.closed {

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -61,6 +61,13 @@ func NewAsyncSender(client client.LogSender, options ...AsyncSenderOption) *Asyn
 
 // Send buffers an entry for async delivery. Non-blocking by default.
 func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]string, timestamp time.Time) error {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return fmt.Errorf("%w: sender is closed", errors.ErrBufferFull)
+	}
+	s.mu.Unlock()
+
 	e := entry{
 		content:   content,
 		labels:    labels,
@@ -86,6 +93,13 @@ func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]
 
 // Flush blocks until all buffered entries have been sent.
 func (s *AsyncSender) Flush() {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		return
+	}
+	s.mu.Unlock()
+
 	flushCh := make(chan struct{})
 	s.buffer <- entry{flushCh: flushCh}
 	<-flushCh

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -29,6 +29,7 @@ type AsyncSender struct {
 	batchSize     int
 	flushInterval time.Duration
 	blockOnFull   bool
+	sendTimeout   time.Duration
 	done          chan struct{}
 	wg            sync.WaitGroup
 	errorHandler  func(error)
@@ -47,6 +48,7 @@ func NewAsyncSender(client client.LogSender, options ...AsyncSenderOption) *Asyn
 		batchSize:     100,
 		flushInterval: 5 * time.Second,
 		blockOnFull:   false,
+		sendTimeout:   30 * time.Second,
 		done:          make(chan struct{}),
 		errorHandler:  func(err error) { log.Printf("cloudlog: send error: %v", err) },
 	}
@@ -228,7 +230,10 @@ func (s *AsyncSender) sendBatch(batch []entry) {
 		})
 	}
 
-	if err := s.client.Send(context.Background(), lokiEntry); err != nil {
+	ctx, cancel := context.WithTimeout(context.Background(), s.sendTimeout)
+	defer cancel()
+
+	if err := s.client.Send(ctx, lokiEntry); err != nil {
 		s.errorHandler(err)
 	}
 }
@@ -269,6 +274,14 @@ func WithErrorHandler(handler func(error)) AsyncSenderOption {
 	return func(s *AsyncSender) {
 		if handler != nil {
 			s.errorHandler = handler
+		}
+	}
+}
+
+func WithSendTimeout(d time.Duration) AsyncSenderOption {
+	return func(s *AsyncSender) {
+		if d > 0 {
+			s.sendTimeout = d
 		}
 	}
 }

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -191,9 +191,7 @@ func labelKey(labels map[string]string) string {
 		if i > 0 {
 			b.WriteByte(',')
 		}
-		b.WriteString(k)
-		b.WriteByte('=')
-		b.WriteString(labels[k])
+		fmt.Fprintf(&b, "%q=%q", k, labels[k])
 	}
 	return b.String()
 }

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -161,6 +161,8 @@ func (s *AsyncSender) worker() {
 				select {
 				case e := <-s.buffer:
 					if e.flushCh != nil {
+						s.sendBatch(batch)
+						batch = batch[:0]
 						close(e.flushCh)
 						continue
 					}

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -69,7 +69,7 @@ func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]
 	s.mu.Lock()
 	if s.closed {
 		s.mu.Unlock()
-		return fmt.Errorf("%w: sender is closed", errors.ErrBufferFull)
+		return fmt.Errorf("%w", errors.ErrSenderClosed)
 	}
 	s.mu.Unlock()
 
@@ -84,7 +84,7 @@ func (s *AsyncSender) Send(_ context.Context, content []byte, labels map[string]
 		case s.buffer <- e:
 			return nil
 		case <-s.done:
-			return fmt.Errorf("%w: sender is closed", errors.ErrBufferFull)
+			return fmt.Errorf("%w", errors.ErrSenderClosed)
 		}
 	}
 

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -106,8 +106,16 @@ func (s *AsyncSender) Flush() {
 	s.mu.Unlock()
 
 	flushCh := make(chan struct{})
-	s.buffer <- entry{flushCh: flushCh}
-	<-flushCh
+	select {
+	case s.buffer <- entry{flushCh: flushCh}:
+	case <-s.done:
+		return
+	}
+
+	select {
+	case <-flushCh:
+	case <-s.done:
+	}
 }
 
 // Close flushes remaining entries and stops the background worker.

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -116,6 +116,10 @@ func (s *AsyncSender) Close() {
 		s.mu.Unlock()
 		return
 	}
+	// Flush before marking closed so Flush() actually drains via marker
+	s.mu.Unlock()
+	s.Flush()
+	s.mu.Lock()
 	s.closed = true
 	s.mu.Unlock()
 

--- a/logger/async_sender.go
+++ b/logger/async_sender.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -171,47 +173,63 @@ func (s *AsyncSender) worker() {
 	}
 }
 
-// sendBatch groups entries by job label and sends one LokiEntry per job.
+// labelKey returns a string key for grouping entries by their full label set.
+func labelKey(labels map[string]string) string {
+	// Build a deterministic key from sorted label pairs
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(labels[k])
+	}
+	return b.String()
+}
+
+// sendBatch groups entries by their full label set and sends one LokiEntry per group.
 func (s *AsyncSender) sendBatch(batch []entry) {
 	if len(batch) == 0 {
 		return
 	}
 
-	// Group entries by job label
-	byJob := make(map[string][]entry)
-	for _, e := range batch {
-		job := e.labels["job"]
-		byJob[job] = append(byJob[job], e)
+	type streamGroup struct {
+		labels map[string]string
+		values [][]string
 	}
 
-	for job, entries := range byJob {
-		values := make([][]string, 0, len(entries))
-		for _, e := range entries {
-			values = append(values, []string{
-				fmt.Sprintf("%d", e.timestamp.UnixNano()),
-				string(e.content),
-			})
+	groups := make(map[string]*streamGroup)
+	for _, e := range batch {
+		key := labelKey(e.labels)
+		g, ok := groups[key]
+		if !ok {
+			g = &streamGroup{labels: e.labels}
+			groups[key] = g
 		}
+		g.values = append(g.values, []string{
+			fmt.Sprintf("%d", e.timestamp.UnixNano()),
+			string(e.content),
+		})
+	}
 
-		// Use labels from first entry, ensure job is set
-		labels := make(map[string]string)
-		for k, v := range entries[0].labels {
-			labels[k] = v
-		}
-		labels["job"] = job
+	lokiEntry := client.LokiEntry{
+		Streams: make([]client.LokiStream, 0, len(groups)),
+	}
+	for _, g := range groups {
+		lokiEntry.Streams = append(lokiEntry.Streams, client.LokiStream{
+			Stream: g.labels,
+			Values: g.values,
+		})
+	}
 
-		lokiEntry := client.LokiEntry{
-			Streams: []client.LokiStream{
-				{
-					Stream: labels,
-					Values: values,
-				},
-			},
-		}
-
-		if err := s.client.Send(context.Background(), lokiEntry); err != nil {
-			s.errorHandler(err)
-		}
+	if err := s.client.Send(context.Background(), lokiEntry); err != nil {
+		s.errorHandler(err)
 	}
 }
 

--- a/logger/async_sender_test.go
+++ b/logger/async_sender_test.go
@@ -257,3 +257,22 @@ func TestAsyncSender_DoubleCloseIsSafe(t *testing.T) {
 	sender.Close()
 	sender.Close() // should not panic
 }
+
+func TestAsyncSender_SendAfterClose(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock)
+	sender.Close()
+
+	err := sender.Send(ctx, []byte(`{"msg":"late"}`), map[string]string{"job": "test"}, time.Now())
+	assert.Error(t, err)
+	assert.True(t, stderrors.Is(err, errors.ErrBufferFull))
+}
+
+func TestAsyncSender_FlushAfterClose(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock)
+	sender.Close()
+
+	// Should return immediately, not block forever
+	sender.Flush()
+}

--- a/logger/async_sender_test.go
+++ b/logger/async_sender_test.go
@@ -7,13 +7,12 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	stderrors "errors"
 
 	"github.com/mwazovzky/cloudlog/client"
 	"github.com/mwazovzky/cloudlog/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	stderrors "errors"
 )
 
 // asyncMockLogSender captures LokiEntry sends for testing

--- a/logger/async_sender_test.go
+++ b/logger/async_sender_test.go
@@ -1,0 +1,259 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mwazovzky/cloudlog/client"
+	"github.com/mwazovzky/cloudlog/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	stderrors "errors"
+)
+
+// asyncMockLogSender captures LokiEntry sends for testing
+type asyncMockLogSender struct {
+	mu      sync.Mutex
+	entries []client.LokiEntry
+	err     error
+}
+
+func (m *asyncMockLogSender) Send(_ context.Context, entry client.LokiEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	m.entries = append(m.entries, entry)
+	return nil
+}
+
+func (m *asyncMockLogSender) getEntries() []client.LokiEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]client.LokiEntry{}, m.entries...)
+}
+
+func (m *asyncMockLogSender) totalValues() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	count := 0
+	for _, e := range m.entries {
+		for _, s := range e.Streams {
+			count += len(s.Values)
+		}
+	}
+	return count
+}
+
+func TestAsyncSender_BasicSendAndFlush(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock, WithBatchSize(10))
+	defer sender.Close()
+
+	labels := map[string]string{"job": "test"}
+	err := sender.Send(ctx, []byte(`{"msg":"hello"}`), labels, time.Now())
+	assert.NoError(t, err)
+
+	sender.Flush()
+
+	assert.Equal(t, 1, mock.totalValues())
+}
+
+func TestAsyncSender_Batching(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock, WithBatchSize(5), WithFlushInterval(time.Hour))
+	defer sender.Close()
+
+	labels := map[string]string{"job": "test"}
+	for i := 0; i < 5; i++ {
+		err := sender.Send(ctx, []byte(fmt.Sprintf(`{"i":%d}`, i)), labels, time.Now())
+		assert.NoError(t, err)
+	}
+
+	sender.Flush()
+
+	entries := mock.getEntries()
+	require.Len(t, entries, 1)
+	assert.Len(t, entries[0].Streams[0].Values, 5)
+}
+
+func TestAsyncSender_FlushInterval(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock,
+		WithBatchSize(1000),
+		WithFlushInterval(50*time.Millisecond),
+	)
+	defer sender.Close()
+
+	labels := map[string]string{"job": "test"}
+	err := sender.Send(ctx, []byte(`{"msg":"tick"}`), labels, time.Now())
+	assert.NoError(t, err)
+
+	// Wait for flush interval to fire
+	time.Sleep(150 * time.Millisecond)
+
+	assert.Equal(t, 1, mock.totalValues())
+}
+
+func TestAsyncSender_FlushDrainsAll(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock, WithBatchSize(1000))
+	defer sender.Close()
+
+	labels := map[string]string{"job": "test"}
+	for i := 0; i < 50; i++ {
+		err := sender.Send(ctx, []byte(fmt.Sprintf(`{"i":%d}`, i)), labels, time.Now())
+		assert.NoError(t, err)
+	}
+
+	sender.Flush()
+
+	assert.Equal(t, 50, mock.totalValues())
+}
+
+func TestAsyncSender_CloseFlushesAndStops(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock, WithBatchSize(1000))
+
+	labels := map[string]string{"job": "test"}
+	for i := 0; i < 10; i++ {
+		err := sender.Send(ctx, []byte(fmt.Sprintf(`{"i":%d}`, i)), labels, time.Now())
+		assert.NoError(t, err)
+	}
+
+	sender.Close()
+
+	assert.Equal(t, 10, mock.totalValues())
+}
+
+func TestAsyncSender_BufferFullNonBlocking(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock,
+		WithBufferSize(2),
+		WithBatchSize(1000),
+		WithFlushInterval(time.Hour),
+	)
+	defer sender.Close()
+
+	labels := map[string]string{"job": "test"}
+
+	// Fill the buffer (2 entries) plus one that may or may not fit depending on worker timing
+	var bufferFullErr error
+	for i := 0; i < 100; i++ {
+		err := sender.Send(ctx, []byte(`{"msg":"fill"}`), labels, time.Now())
+		if err != nil {
+			bufferFullErr = err
+			break
+		}
+	}
+
+	require.Error(t, bufferFullErr)
+	assert.True(t, stderrors.Is(bufferFullErr, errors.ErrBufferFull))
+}
+
+func TestAsyncSender_BufferFullBlocking(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock,
+		WithBufferSize(1),
+		WithBatchSize(1),
+		WithBlockOnFull(true),
+	)
+	defer sender.Close()
+
+	labels := map[string]string{"job": "test"}
+
+	// Should not block forever — worker drains the buffer
+	for i := 0; i < 10; i++ {
+		err := sender.Send(ctx, []byte(fmt.Sprintf(`{"i":%d}`, i)), labels, time.Now())
+		assert.NoError(t, err)
+	}
+
+	sender.Flush()
+	assert.Equal(t, 10, mock.totalValues())
+}
+
+func TestAsyncSender_ErrorHandler(t *testing.T) {
+	mock := &asyncMockLogSender{err: fmt.Errorf("loki down")}
+	var errorCount atomic.Int32
+	sender := NewAsyncSender(mock,
+		WithBatchSize(1),
+		WithErrorHandler(func(_ error) {
+			errorCount.Add(1)
+		}),
+	)
+	defer sender.Close()
+
+	labels := map[string]string{"job": "test"}
+	err := sender.Send(ctx, []byte(`{"msg":"fail"}`), labels, time.Now())
+	assert.NoError(t, err) // Send itself succeeds (buffered)
+
+	sender.Flush()
+
+	assert.GreaterOrEqual(t, errorCount.Load(), int32(1))
+}
+
+func TestAsyncSender_ConcurrentSend(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock,
+		WithBufferSize(1000),
+		WithBatchSize(50),
+	)
+	defer sender.Close()
+
+	var wg sync.WaitGroup
+	labels := map[string]string{"job": "test"}
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = sender.Send(ctx, []byte(fmt.Sprintf(`{"g":%d,"i":%d}`, n, j)), labels, time.Now())
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	sender.Flush()
+
+	assert.Equal(t, 1000, mock.totalValues())
+}
+
+func TestAsyncSender_GroupsByJob(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock, WithBatchSize(10))
+	defer sender.Close()
+
+	err := sender.Send(ctx, []byte(`{"msg":"a"}`), map[string]string{"job": "svc-a"}, time.Now())
+	assert.NoError(t, err)
+	err = sender.Send(ctx, []byte(`{"msg":"b"}`), map[string]string{"job": "svc-b"}, time.Now())
+	assert.NoError(t, err)
+
+	sender.Flush()
+
+	entries := mock.getEntries()
+	// May be 1 or 2 LokiEntry calls depending on batching, but total values = 2
+	assert.Equal(t, 2, mock.totalValues())
+
+	// Verify each stream has the correct job
+	for _, e := range entries {
+		for _, s := range e.Streams {
+			job := s.Stream["job"]
+			assert.Contains(t, []string{"svc-a", "svc-b"}, job)
+		}
+	}
+}
+
+func TestAsyncSender_DoubleCloseIsSafe(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock)
+
+	sender.Close()
+	sender.Close() // should not panic
+}

--- a/logger/async_sender_test.go
+++ b/logger/async_sender_test.go
@@ -319,7 +319,7 @@ func TestAsyncSender_SendAfterClose(t *testing.T) {
 
 	err := sender.Send(ctx, []byte(`{"msg":"late"}`), map[string]string{"job": "test"}, time.Now())
 	assert.Error(t, err)
-	assert.True(t, stderrors.Is(err, errors.ErrBufferFull))
+	assert.True(t, stderrors.Is(err, errors.ErrSenderClosed))
 }
 
 func TestAsyncSender_FlushAfterClose(t *testing.T) {

--- a/logger/async_sender_test.go
+++ b/logger/async_sender_test.go
@@ -223,6 +223,7 @@ func TestAsyncSender_ConcurrentSend(t *testing.T) {
 	sender := NewAsyncSender(mock,
 		WithBufferSize(1000),
 		WithBatchSize(50),
+		WithBlockOnFull(true),
 	)
 	defer sender.Close()
 
@@ -234,7 +235,8 @@ func TestAsyncSender_ConcurrentSend(t *testing.T) {
 		go func(n int) {
 			defer wg.Done()
 			for j := 0; j < 100; j++ {
-				_ = sender.Send(ctx, []byte(fmt.Sprintf(`{"g":%d,"i":%d}`, n, j)), labels, time.Now())
+				err := sender.Send(ctx, []byte(fmt.Sprintf(`{"g":%d,"i":%d}`, n, j)), labels, time.Now())
+				assert.NoError(t, err)
 			}
 		}(i)
 	}

--- a/logger/async_sender_test.go
+++ b/logger/async_sender_test.go
@@ -95,10 +95,9 @@ func TestAsyncSender_FlushInterval(t *testing.T) {
 	err := sender.Send(ctx, []byte(`{"msg":"tick"}`), labels, time.Now())
 	assert.NoError(t, err)
 
-	// Wait for flush interval to fire
-	time.Sleep(150 * time.Millisecond)
-
-	assert.Equal(t, 1, mock.totalValues())
+	assert.Eventually(t, func() bool {
+		return mock.totalValues() == 1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestAsyncSender_FlushDrainsAll(t *testing.T) {

--- a/logger/async_sender_test.go
+++ b/logger/async_sender_test.go
@@ -250,6 +250,38 @@ func TestAsyncSender_GroupsByJob(t *testing.T) {
 	}
 }
 
+func TestAsyncSender_GroupsByFullLabelSet(t *testing.T) {
+	mock := &asyncMockLogSender{}
+	sender := NewAsyncSender(mock, WithBatchSize(10))
+	defer sender.Close()
+
+	// Same job, different user_id — should produce separate streams
+	err := sender.Send(ctx, []byte(`{"msg":"a"}`), map[string]string{"job": "svc", "user_id": "1"}, time.Now())
+	assert.NoError(t, err)
+	err = sender.Send(ctx, []byte(`{"msg":"b"}`), map[string]string{"job": "svc", "user_id": "2"}, time.Now())
+	assert.NoError(t, err)
+	// Same labels as first — should be grouped with it
+	err = sender.Send(ctx, []byte(`{"msg":"c"}`), map[string]string{"job": "svc", "user_id": "1"}, time.Now())
+	assert.NoError(t, err)
+
+	sender.Flush()
+
+	entries := mock.getEntries()
+	require.Len(t, entries, 1) // single HTTP request
+
+	// Should have 2 streams: user_id=1 (2 values) and user_id=2 (1 value)
+	streams := entries[0].Streams
+	assert.Len(t, streams, 2)
+
+	for _, s := range streams {
+		if s.Stream["user_id"] == "1" {
+			assert.Len(t, s.Values, 2)
+		} else {
+			assert.Len(t, s.Values, 1)
+		}
+	}
+}
+
 func TestAsyncSender_DoubleCloseIsSafe(t *testing.T) {
 	mock := &asyncMockLogSender{}
 	sender := NewAsyncSender(mock)

--- a/logger/async_sender_test.go
+++ b/logger/async_sender_test.go
@@ -133,28 +133,49 @@ func TestAsyncSender_CloseFlushesAndStops(t *testing.T) {
 }
 
 func TestAsyncSender_BufferFullNonBlocking(t *testing.T) {
+	// Use a LogSender that blocks forever so the worker can't drain the buffer
+	blockCh := make(chan struct{})
 	mock := &asyncMockLogSender{}
-	sender := NewAsyncSender(mock,
+	blockingSender := &blockingLogSender{ch: blockCh, delegate: mock}
+
+	sender := NewAsyncSender(blockingSender,
 		WithBufferSize(2),
-		WithBatchSize(1000),
-		WithFlushInterval(time.Hour),
+		WithBatchSize(1),
 	)
-	defer sender.Close()
+	defer func() {
+		close(blockCh) // unblock the sender so Close() can finish
+		sender.Close()
+	}()
 
 	labels := map[string]string{"job": "test"}
 
-	// Fill the buffer (2 entries) plus one that may or may not fit depending on worker timing
+	// First send triggers the worker to call blockingSender.Send which blocks
+	// Second send fills the buffer (size=1 remaining since worker pulled one)
+	// Third send should get ErrBufferFull
 	var bufferFullErr error
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		err := sender.Send(ctx, []byte(`{"msg":"fill"}`), labels, time.Now())
 		if err != nil {
 			bufferFullErr = err
 			break
 		}
+		// Small delay to let worker pick up the first entry and block
+		time.Sleep(time.Millisecond)
 	}
 
 	require.Error(t, bufferFullErr)
 	assert.True(t, stderrors.Is(bufferFullErr, errors.ErrBufferFull))
+}
+
+// blockingLogSender blocks on Send until ch is closed, then delegates
+type blockingLogSender struct {
+	ch       chan struct{}
+	delegate client.LogSender
+}
+
+func (b *blockingLogSender) Send(ctx context.Context, entry client.LokiEntry) error {
+	<-b.ch
+	return b.delegate.Send(ctx, entry)
 }
 
 func TestAsyncSender_BufferFullBlocking(t *testing.T) {

--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,7 @@ if err != nil {
 | `WithFlushInterval(d)`   | 5s      | Max time between sends            |
 | `WithBlockOnFull(bool)`  | false   | Block vs return ErrBufferFull     |
 | `WithErrorHandler(fn)`   | stderr  | Callback for background errors    |
+| `WithSendTimeout(d)`     | 30s     | Timeout per HTTP batch send       |
 
 ### Formatter Options
 

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,26 @@ func main() {
 }
 ```
 
+## Async Logging
+
+For high-throughput scenarios, use `AsyncSender` to buffer and batch log entries:
+
+```go
+client := cloudlog.NewClient(url, user, token, httpClient)
+sender := cloudlog.NewAsyncSender(client,
+	cloudlog.WithBufferSize(10000),
+	cloudlog.WithBatchSize(100),
+	cloudlog.WithFlushInterval(time.Second),
+)
+logger := cloudlog.New(sender, cloudlog.WithJob("api-service"))
+
+logger.Info(ctx, "Request handled", "status", 200) // non-blocking
+
+// Before shutdown
+sender.Flush()
+sender.Close()
+```
+
 ## Metadata
 
 ```go
@@ -111,6 +131,16 @@ if err != nil {
 | `WithFormatter(formatter)` | Sets a custom formatter                  |
 | `WithLabelKeys(keys...)`   | Promotes keys to Loki stream labels      |
 | `WithMinLevel(level)`      | Sets minimum log level                   |
+
+### AsyncSender Options
+
+| Option                   | Default | Description                       |
+| ------------------------ | ------- | --------------------------------- |
+| `WithBufferSize(n)`      | 1000    | Buffer channel capacity           |
+| `WithBatchSize(n)`       | 100     | Max entries per HTTP request      |
+| `WithFlushInterval(d)`   | 5s      | Max time between sends            |
+| `WithBlockOnFull(bool)`  | false   | Block vs return ErrBufferFull     |
+| `WithErrorHandler(fn)`   | stderr  | Callback for background errors    |
 
 ### Formatter Options
 

--- a/readme.md
+++ b/readme.md
@@ -72,8 +72,7 @@ logger := cloudlog.New(sender, cloudlog.WithJob("api-service"))
 
 logger.Info(ctx, "Request handled", "status", 200) // non-blocking
 
-// Before shutdown
-sender.Flush()
+// Before shutdown (Close flushes remaining entries)
 sender.Close()
 ```
 


### PR DESCRIPTION
Summary

  - Add AsyncSender implementing the Sender interface with non-blocking,
  buffered delivery
  - Background worker batches entries and groups by full label set (one stream
  per distinct label map)
  - Flush via marker entry with response channel; Close flushes then stops
  worker
  - Non-blocking Send by default (ErrBufferFull), optional
  WithBlockOnFull(true)
  - ErrSenderClosed returned when sending after Close
  - Configurable: buffer size, batch size, flush interval, send timeout, error
  handler
  - Context intentionally not propagated to background HTTP sends;
  WithSendTimeout bounds duration

  Test plan

  - Basic send and flush
  - Batching by size and flush interval
  - Grouping by full label set (not just job)
  - Buffer full: non-blocking (deterministic with blocking mock) and blocking
  modes
  - Send/Flush after Close return immediately
  - Concurrent Close is safe (sync.Once)
  - Concurrent Send from multiple goroutines
  - Error handler called on background send failure
  - Flush marker in drain path sends accumulated batch before acknowledging
  - Race detector passes (go test -race ./...)
  - Linter passes (golangci-lint run ./...)